### PR TITLE
Replace OAuth 2.0 with a custom authorization header

### DIFF
--- a/debug/v0.1/debug_provider.md
+++ b/debug/v0.1/debug_provider.md
@@ -30,8 +30,6 @@ Description:
 
 The provider allows an instance to make a HTTP `POST` call to `/debug/log`.
 
-OAuth 2.0 scope: `debug`
-
 Example call:
 
 ```http
@@ -56,8 +54,6 @@ The provider MUST return a HTTP status code `201` (Created).
 
 The instance allows the provider to make a HTTP `POST` call to
 `/debug/callback`.
-
-OAuth 2.0 scope: `aux:debug`
 
 Example call:
 

--- a/debug/v0.1/instance_openapi.yml
+++ b/debug/v0.1/instance_openapi.yml
@@ -36,17 +36,12 @@ paths:
         '201':
           description: Successful operation
       security:
-        - provider_auth:
-          - debug
+        - provider_auth: []
 components:
   schemas:
     DebugPayload:
       type: object
   securitySchemes:
     provider_auth:
-      type: oauth2
-      flows:
-        clientCredentials:
-          tokenUrl: https://provider.example.com/oauth/token
-          scopes:
-            debug: create debug logs
+      type: http
+      scheme: bearer

--- a/debug/v0.1/provider_openapi.yml
+++ b/debug/v0.1/provider_openapi.yml
@@ -36,17 +36,12 @@ paths:
         '201':
           description: Successful operation
       security:
-        - provider_auth:
-          - debug
+        - provider_auth: []
 components:
   schemas:
     DebugPayload:
       type: object
   securitySchemes:
     provider_auth:
-      type: oauth2
-      flows:
-        clientCredentials:
-          tokenUrl: https://provider.example.com/oauth/token
-          scopes:
-            debug: create debug logs
+      type: http
+      scheme: bearer

--- a/general/v0.1/protocol_basics.md
+++ b/general/v0.1/protocol_basics.md
@@ -46,22 +46,29 @@ Custom API calls are HTTPS calls sending, if necessary, JSON data
 ### Authentication
 
 As described in [03: Registration](registration.md) both FASP and
-fediverse server exchange secret keys. Each MUST send the respective
-secret key as a "bearer token" in the `Authorization` HTTP header with
-every API call.  This means that the fediverse server MUST include the
-secret key it got from the FASP during the registration when calling the
-FASP's APIs. And the FASP must send the secret key it received from the
-fediverse server when it calls its APIs.
+fediverse server exchange client IDs and secret keys. API requests are
+being authenticated by an `Authorization` header with a custom scheme,
+`FASP-HMAC-SHA256`. Included in this header is
+
+* The client ID
+* A UNIX timestamp representing the creation time of the request
+* An HMAC using SHA-256 that authenticates the aforementioned timestamp
+  using the secret key.
 
 Example header:
 
 ```http
-Authorization: Bearer SpBr6rheOp891mwWOfT6Pb"
+Authorization: FASP-HMAC-SHA256
+id=b2ks6vm8p23w, created=1728467285, signature=e2821f5113f2dbb7a331e2f7b0198a0fd35c419ea1dab65403e63443b3d61685
 ```
 
-Both sides MUST validate this token and make sure it is the one
-belonging to the other party. If this validation fails the response MUST
-use the HTTP status code `401` (Unauthorized).
+The header MUST be verified by checking that the signature actually
+authenticates the given timestamp with the secret key belonging to
+the given ID. It SHOULD be verified that the timestamp is within an
+acceptable range, allowing for time drift between servers.
+
+If this validation fails the response MUST use the HTTP status code
+`401` (Unauthorized).
 
 ### Rate Limiting
 

--- a/general/v0.1/protocol_basics.md
+++ b/general/v0.1/protocol_basics.md
@@ -40,19 +40,18 @@ development environments.
 Registration tokens are JSON Web Tokens (JWT) as defined in
 [RFC-7519](https://datatracker.ietf.org/doc/html/rfc7519).
 
-For authentication and authorization of API calls, FASP and fediverse server
-use the OAuth 2.0 protocol as defined in
-[RFC-6749](https://tool.ietf.org/html/rfc6749.html).
-
 Custom API calls are HTTPS calls sending, if necessary, JSON data
 (`Content-Type: application/json`) and receiving JSON data.
 
-### OAuth2, Authentication and Authorization
+### Authentication
 
 As described in [03: Registration](registration.md) both FASP and
-fediverse server use OAuth 2.0 to authorize API calls. Both MUST obtain a valid
-access token and send this as a "bearer token" in the `Authorization`
-HTTP header with every API call.
+fediverse server exchange secret keys. Each MUST send the respective
+secret key as a "bearer token" in the `Authorization` HTTP header with
+every API call.  This means that the fediverse server MUST include the
+secret key it got from the FASP during the registration when calling the
+FASP's APIs. And the FASP must send the secret key it received from the
+fediverse server when it calls its APIs.
 
 Example header:
 
@@ -60,17 +59,9 @@ Example header:
 Authorization: Bearer SpBr6rheOp891mwWOfT6Pb"
 ```
 
-Both FASP and fediverse server MUST expire access tokens, forcing the other
-side to periodically request a new one.
-
-The OAuth 2.0 endpoint to request an access token MUST reside at the
-path `/oauth/token` that is relative to the base URL as described
-above. Existing fediverse software that already uses
-OAuth 2.0 and wants to add FASP support cannot re-use existing
-routes. This simplifies FASP implementation and
-enables fediverse software implementers to separate their existing OAuth
-2.0 implementation for regular API clients from the FASP API if so
-desired.
+Both sides MUST validate this token and make sure it is the one
+belonging to the other party. If this validation fails the response MUST
+use the HTTP status code `401` (Unauthorized).
 
 ### Rate Limiting
 

--- a/general/v0.1/provider_info.md
+++ b/general/v0.1/provider_info.md
@@ -6,8 +6,6 @@ Every FASP must offer a FASP information API endpoint that can be queried to obt
 
 This endpoint can be queried using a `GET` call to `/provider_info`.
 
-OAuth 2.0 scope: `setup`
-
 Example call:
 
 ```http

--- a/general/v0.1/provider_openapi.yml
+++ b/general/v0.1/provider_openapi.yml
@@ -28,8 +28,8 @@ paths:
     post:
       tags:
         - client_credentials
-      summary: Setup an instance
-      description: Create OAuth2.0 application for an instance
+      summary: Setup a fediverse server
+      description: Create client credentials to authenticate against fediverse server
       operationId: createClientCredentials
       requestBody:
         description: Client credentials and base URL  
@@ -44,8 +44,7 @@ paths:
         '422':
           description: Validation exception
       security:
-        - provider_auth:
-          - setup
+        - provider_auth: []
   /provider_info:
     get:
       tags:
@@ -61,8 +60,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProviderInfo'
       security:
-        - provider_auth:
-          - setup
+        - provider_auth: []
 components:
   schemas:
     ClientCredentials:
@@ -117,9 +115,5 @@ components:
           examples: ["0.1", "1.0", "2.4"]
   securitySchemes:
     provider_auth:
-      type: oauth2
-      flows:
-        clientCredentials:
-          tokenUrl: https://provider.example.com/oauth/token
-          scopes:
-            setup: setup an instance
+      type: http
+      scheme: bearer

--- a/general/v0.1/provider_specifications.md
+++ b/general/v0.1/provider_specifications.md
@@ -14,7 +14,6 @@ Every FASP specification MUST include the following:
 * The FASP's HTTP API endpoints
 * The HTTP API an instance needs to implement for the fediverse server to use
   (or a note that none is required)
-* The OAuth 2.0 scopes used
 * A summary of personally identifiable information or other data that
   might be considered sensitive that a FASP may receive
 
@@ -60,37 +59,6 @@ For every capability defined, the specification MUST also include a one
 paragraph description in English that can be used by fediverse software
 to explain the capabilities to fediverse server administrators. It MAY include
 translations into other languages as well. 
-
-### OAuth 2.0 Scopes
-
-FASP specifications MUST define the scopes needed to access the
-FASP's API endpoints. There SHOULD be at least one scope. Scope
-names MUST begin with the capability identifier so as not to collide with
-scopes defined in other FASP specifications.
-
-In the simplest case, there is exactly one scope and the scope's name is
-the capability identifier. Finer grained scopes MAY be defined and MUST
-use a colon (`:`) character to seperate the capability identifier from
-any additional characters.
-
-Examples scope names on the FASP side:
-
-* `debug`
-* `trends`
-* `account_search:write`
-* `media_storage:videos:read`
-
-If a FASP specification also defines an API endpoint on the fediverse server
-side then the same rules apply with one addition:
-
-To prevent collision with existing scope names fediverse
-software might already use, all scope names MUST be prefixed with
-`aux:`.
-
-Example scope names on the instance side:
-
-* `aux:debug`
-* `aux:account_search:write`
 
 ### Privacy Policy Information
 

--- a/general/v0.1/registration.md
+++ b/general/v0.1/registration.md
@@ -30,15 +30,13 @@ administrator. This MAY include but is not limited to the following:
 * URL of the fediverse server(s) to be registered
 * Acceptance of terms of service, data processing agreement, and/or privacy policy
 
-A successful registration results in the FASP creating an OAuth 2.0
-application for the fediverse server, including a client identifier (ID) and
-secret. FASP MUST grant the application all the scopes defined here and in
-the FASP specifications of the capabilities the FASP advertises
-to the fediverse server (see section [04: Provider Info](provider_info.md)).
-FASP specifications MAY define exceptions to this rule.
+A successful registration results in the FASP creating a secret key and
+a client identifier (ID) for the fediverse server. The secret key MUST
+be a random number of at least 128 bits encoded using base64.
 
-After registration, FASP MUST present the fediverse server
-administrator a registration token that can be copied into the fediverse server configuration.
+After registration, FASP MUST present the fediverse server administrator
+a registration token that can be copied into the fediverse server
+configuration.
 
 The registration token is a JSON Web Token (JWT) that MUST include the
 registered claims `iss` and `sub` and the private claim `sec`. It MAY
@@ -47,8 +45,8 @@ contain the registered claim `exp`.
 These claims MUST contain the following:
 
 * `iss`: The base URI for API requests to the FASP.
-* `sub`: The OAuth 2.0 client identifier
-* `sec`: The OAuth 2.0 client secret
+* `sub`: The client identifier
+* `sec`: The client secret key
 * `exp`: An optional expiration time
 
 An example payload:
@@ -61,10 +59,6 @@ An example payload:
   "exp": 1726498179
 }
 ```
-
-FASPs SHOULD offer a way to re-generate the OAuth credentials and
-this token in case it gets lost or a fediverse server needs to be reinstalled
-from scratch.
 
 The following is a sketch of how this may look in the abstract:
 
@@ -95,20 +89,15 @@ This validation MUST include:
 ![A bare-bones web form to add a provider with a textarea for the registration token](../../images/add_provider.svg)
 
 After successful submission of this data, the fediverse software MUST
-persist it and initiate an OAuth 2.0 "client credentials" flow to
-obtain an access token. This token can then be used to authenticate
-subsequent API calls.
+persist it.
 
-If authorization was successful the instance MUST create and persist an
-OAuth 2.0 application representing the FASP, including a client ID
-and a secret.
+It MUST then generate a client ID and a secret key for the FASP
+analogous to how the FASP did for the fediverse software.
 
-It MUST communicate its base URL, the generated client ID and secret to
-the FASP using the client credentials API endpoint.
+It MUST communicate its base URL, the generated client ID and secret key
+to the FASP using the client credentials API endpoint.
 
 Example request:
-
-OAuth 2.0 scope: `setup`
 
 ```http
 POST /client_credentials


### PR DESCRIPTION
Fixes #24 

See that issue for a discussion.

Note that this is currently only a draft. The documentation itself is complete but the OpenAPI files still need adjusting, and this is not straight-forward with this approach here.