### PR TITLE
Clarify versioning and capability relationships

### DIFF
--- a/general/v0.1/provider_specifications.md
+++ b/general/v0.1/provider_specifications.md
@@ -55,6 +55,13 @@ existing implementations SHOULD increase the minor version number.
 Formatting changes, spelling and grammar corrections MAY increase the
 minor version number.
 
+If only the details for a single capability change but the specification
+includes several capabilities this means the version number would change
+for all capabilities even for those that remain unchanged. If this
+happens it might be a signal that the capabilities are not closely
+related after all and should be extracted to their own separate
+specifications.
+
 ### Capabilities
 
 Every FASP specification MUST define at least one capability. It MAY


### PR DESCRIPTION
The way we specifies it in the current draft means that every incompatible change would increase the version number of a specification and thus for *all* included capabilities. This would be really awkward if it results in capabilities v2, v3, etc. that are all identical.

I am not sure if we will ever need per-capability versions and I sure hope we will not, but I wanted to address this issue in some way.

This might also help decide how to "slice" provider specifications. If one specification includes capabilities that are likely to evolve independently of each other, this might warrant putting them in separate specifications.