### PR TITLE
Some clarifications and fixes from implementation

### DIFF
--- a/general/v0.1/protocol_basics.md
+++ b/general/v0.1/protocol_basics.md
@@ -127,6 +127,10 @@ acceptable range, allowing for time drift between servers.
 If this validation fails the response MUST use the HTTP status code
 `401` (Unauthorized).
 
+Responses to API requests MUST be signed in the same way, except that
+they MUST use the derived component `@status` and the `content-digest`
+HTTP header to generate the signature base.
+
 ### Rate Limiting
 
 FASPs MAY impose rate limiting on API endpoints, e.g. if the requested capability is

--- a/general/v0.1/provider_info.md
+++ b/general/v0.1/provider_info.md
@@ -17,7 +17,7 @@ Example response:
 ```json
 {
   "name": "Example FASP",
-  "privacy_policy": [
+  "privacyPolicy": [
     {
       "url": "https://fasp.example.com/privacy.html",
       "language": "en"
@@ -33,14 +33,14 @@ Example response:
       "version": "1.0"
     }
   ],
-  "sign_in_url": "https://fasp.example.com/sign_in",
-  "contact_email": "support@fasp.example.com",
-  "fediverse_account": "@fasp@fedi.example.com"
+  "signInUrl": "https://fasp.example.com/sign_in",
+  "contactEmail": "support@fasp.example.com",
+  "fediverseAccount": "@fasp@fedi.example.com"
 }
 ```
 
-The FASP info MUST contain the keys `name`, `privacy_policy` and
-`capabilities`. The key `sign_in_url` MUST be present if the FASP offers a
+The FASP info MUST contain the keys `name`, `privacyPolicy` and
+`capabilities`. The key `signInUrl` MUST be present if the FASP offers a
 way for a fediverse server administrator to sign in (e.g. to edit settings, show
 statistics etc.). Otherwise it MAY be absent.
 
@@ -50,7 +50,7 @@ The values are defined as follows:
   This is the name of this installation of the FASP software. It will be
   displayed to fediverse server administrators and SHOULD be as descriptive as possible
   for them to identify the FASP.
-* `privacy_policy`: This MUST be an array. In case the provider does not
+* `privacyPolicy`: This MUST be an array. In case the provider does not
   receive any kind of personally identifiable information or other data that
   might be considered sensitive this MAY be empty. Otherwise it MUST contain
   one object containing the keys `url` and `language` for each language the
@@ -66,11 +66,11 @@ The values are defined as follows:
       specifications for the list of capabilites and their identifiers.
     * `version`: The version of the specification for this capability that this
       FASP supports.
-* `sign_in_url`: If present it MUST contain a string representing the URL where
+* `signInUrl`: If present it MUST contain a string representing the URL where
   a fediverse server administrator can sign in to the FASP.
-* `contact_email`: MAY be optionally included to communicate an email
+* `contactEmail`: MAY be optionally included to communicate an email
   address to contact the FASP's operator(s).
-* `fediverse_account`: MAY be optionally included to point to a
+* `fediverseAccount`: MAY be optionally included to point to a
   fediverse account that can be followed to receive updates about the
   FASP.
 

--- a/general/v0.1/registration.md
+++ b/general/v0.1/registration.md
@@ -47,7 +47,7 @@ values:
   administrator during registration to make it recognizable.
 * `baseUrl`: The base URL of the FASP
 * `serverId`: The identifier for the server that the FASP generated
-* `publicKey`: The public key of the FASP
+* `publicKey`: The public key of the FASP, base64 encoded
 
 An example payload:
 
@@ -67,7 +67,7 @@ reply with an HTTP status code `201` (Created) and a JSON object that
 contains the following keys and values:
 
 * `faspId`: The identifier the server generated for the FASP
-* `publicKey`: The public key of the fediverse server
+* `publicKey`: The public key of the fediverse server, base64 encoded
 * `registrationCompletionUri`: An URI to redirect to in order to finish the
   registration
 


### PR DESCRIPTION
While trying to implement the latest specs, I noticed some inconsistencies and missing bits:

* API authentication with HTTP Message Signatures only talked about requests and did not mention what to do with responses. When you have jumped through all the hoops to make the signatures work, it makes sense to just sign the responses as well.
* Not all JSON keys were camelCased (I spend too much time in ruby-land, I guess). This is fixed now.
* Ed25519 keys are base64 encoded. This is a tiny detail that was already implied, but implementers need to know this when they want to serialize the keys into JSON so it is best to make it explicit.