### PR TITLE
Fix missing curly brace in data_sharing example

### DIFF
--- a/discovery/data_sharing/v0.1/data_sharing.md
+++ b/discovery/data_sharing/v0.1/data_sharing.md
@@ -251,6 +251,7 @@ Example payload:
   "source": {
     "subscription": {
       "id": "58152"
+    }
   },
   "category": "content",
   "eventType": "new",


### PR DESCRIPTION
Noticed this when quoting in _that_ issue.